### PR TITLE
Add export command and fix docker CLI updates

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -38,7 +38,7 @@ func apply(c *cli.Context) error {
 	for _, stack := range stacks {
 		filter := filters.NewArgs()
 		filter.Add("label", "com.docker.stack.namespace="+stack.Name)
-		services, servicesErr := swarm.ServiceList(context.Background(), types.ServiceListOptions{Filter: filter})
+		services, servicesErr := swarm.ServiceList(context.Background(), types.ServiceListOptions{Filters: filter})
 		if servicesErr != nil {
 			return cli.NewExitError(servicesErr.Error(), 3)
 		}
@@ -73,7 +73,7 @@ func apply(c *cli.Context) error {
 				if currentService, found := current[name]; found {
 					if sp.PrintServiceSpecDiff(currentService.Spec, expectedService.Spec) {
 						cyan.Printf("Updating service %s\n", name)
-						servicesErr := swarm.ServiceUpdate(context.Background(), currentService.ID, currentService.Version, expectedService.Spec, types.ServiceUpdateOptions{})
+						_, servicesErr := swarm.ServiceUpdate(context.Background(), currentService.ID, currentService.Version, expectedService.Spec, types.ServiceUpdateOptions{})
 						if servicesErr != nil {
 							return cli.NewExitError(servicesErr.Error(), 3)
 						}

--- a/export.go
+++ b/export.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/docker/docker/api/client/bundlefile"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/client"
+	"github.com/urfave/cli"
+	"golang.org/x/net/context"
+)
+
+func export(c *cli.Context) error {
+
+	swarm, swarmErr := client.NewEnvClient()
+	if swarmErr != nil {
+		return cli.NewExitError(swarmErr.Error(), 3)
+	}
+
+	services, servicesErr := swarm.ServiceList(context.Background(), types.ServiceListOptions{})
+
+	if len(services) == 0 {
+		fmt.Println("No services found to export")
+		return nil
+	}
+
+	if servicesErr != nil {
+		return cli.NewExitError(servicesErr.Error(), 3)
+	}
+
+	bundles := map[string]*bundlefile.Bundlefile{}
+	for _, service := range services {
+		var dab *bundlefile.Bundlefile
+		stackName := getStackName(service.Spec.Labels)
+
+		if dab = bundles[stackName]; dab == nil {
+			dab = &bundlefile.Bundlefile{Version: "0.1", Services: map[string]bundlefile.Service{}}
+			bundles[stackName] = dab
+		}
+
+		bundleService, err := getBundleService(service)
+		if err != nil {
+			return cli.NewExitError(servicesErr.Error(), 3)
+		}
+
+		// Remove the stackname from the service in DAB
+		service.Spec.Name = strings.TrimPrefix(service.Spec.Name, fmt.Sprintf("%s_", stackName))
+
+		dab.Services[service.Spec.Name] = *bundleService
+
+	}
+
+	for output, bundle := range bundles {
+		f, err := os.Create(fmt.Sprintf("%s.dab", output))
+		if err != nil {
+			return cli.NewExitError(servicesErr.Error(), 3)
+		}
+
+		err = json.NewEncoder(f).Encode(bundle)
+		if err != nil {
+			return cli.NewExitError(servicesErr.Error(), 3)
+		}
+
+		fmt.Printf("Swarm services exported successfuly for stack: %s \n", output)
+		for name, _ := range bundle.Services {
+			fmt.Println(name)
+		}
+		fmt.Println()
+	}
+
+	return nil
+}
+
+func getStackName(labels map[string]string) string {
+	if stackName, ok := labels["com.docker.stack.namespace"]; ok {
+		return stackName
+	}
+	return "services"
+
+}
+
+func getBundleService(service swarm.Service) (*bundlefile.Service, error) {
+	serviceBundle := &bundlefile.Service{
+		Image:         service.Spec.TaskTemplate.ContainerSpec.Image,
+		Labels:        service.Spec.TaskTemplate.ContainerSpec.Labels,
+		ServiceLabels: service.Spec.Labels,
+		Command:       service.Spec.TaskTemplate.ContainerSpec.Command,
+		Args:          service.Spec.TaskTemplate.ContainerSpec.Args,
+		Env:           service.Spec.TaskTemplate.ContainerSpec.Env,
+		WorkingDir:    &service.Spec.TaskTemplate.ContainerSpec.Dir,
+		User:          &service.Spec.TaskTemplate.ContainerSpec.User,
+		Ports:         []bundlefile.Port{},
+		Networks:      []string{},
+	}
+
+	for _, portcfg := range service.Endpoint.Ports {
+		port := bundlefile.Port{
+			Protocol:      string(portcfg.Protocol),
+			Port:          portcfg.TargetPort,
+			PublishedPort: portcfg.PublishedPort,
+		}
+		serviceBundle.Ports = append(serviceBundle.Ports, port)
+	}
+
+	for _, net := range service.Spec.Networks {
+		serviceBundle.Networks = append(serviceBundle.Networks, net.Aliases...)
+	}
+
+	return serviceBundle, nil
+}

--- a/export.go
+++ b/export.go
@@ -97,6 +97,13 @@ func getBundleService(service swarm.Service) (*bundlefile.Service, error) {
 		Networks:      []string{},
 	}
 
+	if service.Spec.Mode.Global != nil {
+		global := "global"
+		serviceBundle.Mode = &global
+	} else {
+		serviceBundle.Replicas = service.Spec.Mode.Replicated.Replicas
+	}
+
 	for _, portcfg := range service.Endpoint.Spec.Ports {
 		port := bundlefile.Port{
 			Protocol:      string(portcfg.Protocol),

--- a/export.go
+++ b/export.go
@@ -86,8 +86,8 @@ func getStackName(labels map[string]string) string {
 func getBundleService(service swarm.Service) (*bundlefile.Service, error) {
 	serviceBundle := &bundlefile.Service{
 		Image:         service.Spec.TaskTemplate.ContainerSpec.Image,
-		Labels:        service.Spec.TaskTemplate.ContainerSpec.Labels,
-		ServiceLabels: service.Spec.Labels,
+		ServiceLabels: service.Spec.TaskTemplate.ContainerSpec.Labels,
+		Labels:        service.Spec.Labels,
 		Command:       service.Spec.TaskTemplate.ContainerSpec.Command,
 		Args:          service.Spec.TaskTemplate.ContainerSpec.Args,
 		Env:           service.Spec.TaskTemplate.ContainerSpec.Env,
@@ -97,7 +97,7 @@ func getBundleService(service swarm.Service) (*bundlefile.Service, error) {
 		Networks:      []string{},
 	}
 
-	for _, portcfg := range service.Endpoint.Ports {
+	for _, portcfg := range service.Endpoint.Spec.Ports {
 		port := bundlefile.Port{
 			Protocol:      string(portcfg.Protocol),
 			Port:          portcfg.TargetPort,

--- a/output.go
+++ b/output.go
@@ -25,7 +25,7 @@ func output(c *cli.Context) error {
 	for _, stack := range stacks {
 		filter := filters.NewArgs()
 		filter.Add("label", "com.docker.stack.namespace="+stack.Name)
-		services, servicesErr := swarm.ServiceList(context.Background(), types.ServiceListOptions{Filter: filter})
+		services, servicesErr := swarm.ServiceList(context.Background(), types.ServiceListOptions{Filters: filter})
 		if servicesErr != nil {
 			return cli.NewExitError(servicesErr.Error(), 3)
 		}

--- a/types.go
+++ b/types.go
@@ -172,7 +172,7 @@ func (sp *ServicePrinter) _printServiceSpecDiff(namespace string, current, expec
 }
 
 func (sp *ServicePrinter) println(c *color.Color, namespace, current string) {
-	spaces := 50 - len(namespace)
+	spaces := 70 - len(namespace)
 	spaceString := strings.Repeat(" ", spaces)
 	if c != nil {
 		namespace = c.SprintFunc()(namespace)
@@ -182,7 +182,7 @@ func (sp *ServicePrinter) println(c *color.Color, namespace, current string) {
 }
 func (sp *ServicePrinter) printDiffln(c *color.Color, namespace, current, expected string) {
 	action := "=>"
-	spaces := 50 - len(namespace)
+	spaces := 70 - len(namespace)
 	spaceString := strings.Repeat(" ", spaces)
 	if c != nil {
 		namespace = c.SprintFunc()(namespace)

--- a/vendor/github.com/docker/docker/api/client/bundlefile/bundlefile.go
+++ b/vendor/github.com/docker/docker/api/client/bundlefile/bundlefile.go
@@ -14,19 +14,20 @@ type Bundlefile struct {
 
 // Service is a service from a bundlefile
 type Service struct {
-	Image        string
-	Command      []string          `json:",omitempty"`
-	Args         []string          `json:",omitempty"`
-	Env          []string          `json:",omitempty"`
-	Labels       map[string]string `json:",omitempty"`
-	Ports        []Port            `json:",omitempty"`
-	WorkingDir   *string           `json:",omitempty"`
-	User         *string           `json:",omitempty"`
-	Networks     []string          `json:",omitempty"`
-	Replicas     *uint64           `json:",omitempty"`
-	Constraints  []string          `json:",omitempty"`
-	EndpointMode *string           `json:",omitempty"`
-	Mode         *string           `json:",omitempty"`
+	Image         string
+	Command       []string          `json:",omitempty"`
+	Args          []string          `json:",omitempty"`
+	Env           []string          `json:",omitempty"`
+	Labels        map[string]string `json:",omitempty"`
+	ServiceLabels map[string]string `json:",omitempty"`
+	Ports         []Port            `json:",omitempty"`
+	WorkingDir    *string           `json:",omitempty"`
+	User          *string           `json:",omitempty"`
+	Networks      []string          `json:",omitempty"`
+	Replicas      *uint64           `json:",omitempty"`
+	Constraints   []string          `json:",omitempty"`
+	EndpointMode  *string           `json:",omitempty"`
+	Mode          *string           `json:",omitempty"`
 }
 
 // Port is a port as defined in a bundlefile

--- a/vendor/github.com/docker/docker/api/client/stack/common.go
+++ b/vendor/github.com/docker/docker/api/client/stack/common.go
@@ -33,7 +33,7 @@ func GetServices(
 ) ([]swarm.Service, error) {
 	return apiclient.ServiceList(
 		ctx,
-		types.ServiceListOptions{Filter: GetStackFilter(namespace)})
+		types.ServiceListOptions{Filters: GetStackFilter(namespace)})
 }
 
 func GetNetworks(

--- a/wp.go
+++ b/wp.go
@@ -17,12 +17,12 @@ import (
 func main() {
 	app := cli.NewApp()
 	app.Usage = "Manage DAB files as docker swarm service blueprints"
-	app.Version = "0.0.2"
+	app.Version = "0.0.3"
 
 	app.Commands = []cli.Command{
 		{
 			Name:  "plan",
-			Usage: "Plan DAB whaleprint",
+			Usage: "Plan service deployment",
 			ArgsUsage: `[STACK] [STACK...]
 
 Prints an execultion plan to review before applying changes.
@@ -46,7 +46,7 @@ Whaleprint will look for .dab files or use the stack name to load the DAB file.
 		},
 		{
 			Name:  "apply",
-			Usage: "Apply DAB whaleprint",
+			Usage: "Apply service deployment",
 			ArgsUsage: `[STACK] [STACK...]
 
 Applies the execution plan returned by the "whaleprint plan" command
@@ -63,6 +63,14 @@ Whaleprint will look for .dab files or use the stack name to load the DAB file.
 					Usage: "Process specified services only (default [])",
 				},
 			},
+		},
+		{
+			Name:  "export",
+			Usage: "Export stacks to DAB",
+			ArgsUsage: `
+Exports current service definitions to a DAB file
+			`,
+			Action: export,
 		},
 		{
 			Name:  "destroy",


### PR DESCRIPTION
This exports all current swarm services into it's own corresponding DAB stack file.

This PR also enables a new entity `ServiceLabels` in the DAB so you can specify them when managing your services through whaleprint.


@xetorthio 

